### PR TITLE
Update annotation.rb

### DIFF
--- a/lib/iiif/presentation/annotation.rb
+++ b/lib/iiif/presentation/annotation.rb
@@ -7,8 +7,11 @@ module IIIF
       TYPE = 'oa:Annotation'
 
       def required_keys
-        super + %w{ motivation }
+        super + %w{ motivation on }
       end
+      
+      def string_only_keys
+        super + %w{ on }
 
       def abstract_resource_only_keys
         super + [ { key: 'resource', type: IIIF::Presentation::Resource } ]


### PR DESCRIPTION
According to http://iiif.io/api/presentation/2.0/#image-resources, "the URI of the canvas must be repeated in the on field of the Annotation". This patch adds the "on" field to the annotation class and makes it a required field. 

It's worth noting that without this patch, https://github.com/IIIF/presentation-validator will fail the validation for an O'Sullivan generated manifest that contains an annotation. With the patch, it will succeed.